### PR TITLE
feat: 添加基础模板和首页

### DIFF
--- a/sui/templates/sui/base.html
+++ b/sui/templates/sui/base.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="zh-cn">
+<head>
+    <meta charset="UTF-8">
+    <title>{% block title %}SuiTune{% endblock %}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-900 text-white min-h-screen flex items-center justify-center">
+    {% block content %}{% endblock %}
+</body>
+</html>

--- a/sui/templates/sui/index.html
+++ b/sui/templates/sui/index.html
@@ -1,0 +1,16 @@
+{% extends "sui/base.html" %}
+
+{% block content %}
+<button id="play" class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-4 px-8 rounded-full text-xl">随便播</button>
+<script>
+const btn = document.getElementById('play');
+btn.addEventListener('click', () => {
+    fetch('/api/next')
+        .then(resp => resp.json())
+        .then(data => {
+            const audio = new Audio(data.stream_url);
+            audio.play();
+        });
+});
+</script>
+{% endblock %}

--- a/sui/views.py
+++ b/sui/views.py
@@ -1,8 +1,13 @@
+from django.shortcuts import render
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
 from .models import Track
 from .serializers import TrackSerializer
+
+
+def home(request):
+    return render(request, "sui/index.html")
 
 
 class NextTrackView(APIView):

--- a/suitune/urls.py
+++ b/suitune/urls.py
@@ -1,7 +1,9 @@
 from django.contrib import admin
 from django.urls import path, include
+from sui.views import home
 
 urlpatterns = [
+    path('', home, name='home'),
     path('admin/', admin.site.urls),
     path('api/', include('sui.urls')),
 ]


### PR DESCRIPTION
## Summary
- 添加 Tailwind CSS 基础模板
- 实现首页视图与播放按钮

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6893779134308322a92e0398ad7eae2d