### PR TITLE
feat: 接入 Django allauth 登录路由

### DIFF
--- a/sui/templates/account/login.html
+++ b/sui/templates/account/login.html
@@ -1,0 +1,17 @@
+{% extends "sui/base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "登录" %}{% endblock %}
+
+{% block content %}
+<div class="w-full max-w-xs">
+  <form method="post" action="{% url 'account_login' %}" class="bg-gray-800 shadow-md rounded px-8 pt-6 pb-8 mb-4">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit"
+            class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+      {% trans "登录" %}
+    </button>
+  </form>
+</div>
+{% endblock %}

--- a/suitune/urls.py
+++ b/suitune/urls.py
@@ -6,4 +6,5 @@ urlpatterns = [
     path('', home, name='home'),
     path('admin/', admin.site.urls),
     path('api/', include('sui.urls')),
+    path('accounts/', include('allauth.urls')),
 ]


### PR DESCRIPTION
## Summary
- 在 `suitune/urls.py` 中挂载 `allauth` 的 `accounts/` 路由，提供基本登录页面
- 新增 `account/login.html` 模板，使用 Tailwind 构建简单登录表单

## Testing
- `python manage.py test` *(failed: ModuleNotFoundError: No module named 'django')*
- `pip install .` *(failed: Could not find a version that satisfies the requirement setuptools)*

------
https://chatgpt.com/codex/tasks/task_e_689379f323588322b1f76cb5c54e3dff