### PR TITLE
Add Django allauth login/logout support with simple responsive UI

### DIFF
--- a/sui/adapter.py
+++ b/sui/adapter.py
@@ -1,0 +1,9 @@
+from allauth.account.adapter import DefaultAccountAdapter
+
+
+class NoSignupAccountAdapter(DefaultAccountAdapter):
+    """Account adapter that disables user self-registration."""
+
+    def is_open_for_signup(self, request):  # pragma: no cover - configuration only
+        return False
+

--- a/sui/templates/account/login.html
+++ b/sui/templates/account/login.html
@@ -4,14 +4,16 @@
 {% block title %}{% trans "登录" %}{% endblock %}
 
 {% block content %}
-<div class="w-full max-w-xs">
-  <form method="post" action="{% url 'account_login' %}" class="bg-gray-800 shadow-md rounded px-8 pt-6 pb-8 mb-4">
-    {% csrf_token %}
-    {{ form.as_p }}
-    <button type="submit"
-            class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
-      {% trans "登录" %}
-    </button>
-  </form>
+<div class="flex items-center justify-center min-h-[60vh]">
+  <div class="w-full max-w-xs">
+    <form method="post" action="{% url 'account_login' %}" class="bg-gray-800 shadow-md rounded px-8 pt-6 pb-8 mb-4">
+      {% csrf_token %}
+      {{ form.as_p }}
+      <button type="submit"
+              class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded w-full">
+        {% trans "登录" %}
+      </button>
+    </form>
+  </div>
 </div>
 {% endblock %}

--- a/sui/templates/sui/base.html
+++ b/sui/templates/sui/base.html
@@ -30,12 +30,21 @@
                         SuiTune
                     </a>
                     <div class="flex items-center space-x-2">
-                        <a href="/favorites/" class="w-8 h-8 bg-white/10 hover:bg-white/20 rounded-full flex items-center justify-center transition-all duration-200">
-                            <i class="fas fa-heart text-pink-400 text-sm"></i>
-                        </a>
-                        <a href="/admin/" class="w-8 h-8 bg-white/10 hover:bg-white/20 rounded-full flex items-center justify-center transition-all duration-200">
-                            <i class="fas fa-cog text-gray-300 text-sm"></i>
-                        </a>
+                    <a href="/favorites/" class="w-8 h-8 bg-white/10 hover:bg-white/20 rounded-full flex items-center justify-center transition-all duration-200">
+                        <i class="fas fa-heart text-pink-400 text-sm"></i>
+                    </a>
+                    <a href="/admin/" class="w-8 h-8 bg-white/10 hover:bg-white/20 rounded-full flex items-center justify-center transition-all duration-200">
+                        <i class="fas fa-cog text-gray-300 text-sm"></i>
+                    </a>
+                    {% if user.is_authenticated %}
+                    <a href="{% url 'account_logout' %}" class="w-8 h-8 bg-white/10 hover:bg-white/20 rounded-full flex items-center justify-center transition-all duration-200">
+                        <i class="fas fa-right-from-bracket text-gray-300 text-sm"></i>
+                    </a>
+                    {% else %}
+                    <a href="{% url 'account_login' %}" class="w-8 h-8 bg-white/10 hover:bg-white/20 rounded-full flex items-center justify-center transition-all duration-200">
+                        <i class="fas fa-user text-gray-300 text-sm"></i>
+                    </a>
+                    {% endif %}
                     </div>
                 </div>
                 
@@ -93,6 +102,15 @@
                     <a href="/admin/" class="text-gray-300 hover:text-white transition-colors">
                         <i class="fas fa-cog"></i>
                     </a>
+                    {% if user.is_authenticated %}
+                    <a href="{% url 'account_logout' %}" class="text-gray-300 hover:text-white transition-colors">
+                        <i class="fas fa-right-from-bracket"></i>
+                    </a>
+                    {% else %}
+                    <a href="{% url 'account_login' %}" class="text-gray-300 hover:text-white transition-colors">
+                        <i class="fas fa-user"></i>
+                    </a>
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/suitune/settings.py
+++ b/suitune/settings.py
@@ -80,3 +80,12 @@ MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+LOGIN_REDIRECT_URL = '/'
+ACCOUNT_LOGOUT_REDIRECT_URL = '/'
+ACCOUNT_LOGOUT_ON_GET = True
+ACCOUNT_ADAPTER = 'sui.adapter.NoSignupAccountAdapter'
+ACCOUNT_AUTHENTICATION_METHOD = 'username'
+ACCOUNT_EMAIL_VERIFICATION = 'none'
+ACCOUNT_EMAIL_REQUIRED = False
+LOGIN_URL = '/accounts/login/'


### PR DESCRIPTION
## Summary
- Integrate login and logout actions into navigation bar with FontAwesome icons
- Center login form and simplify styling for responsive design
- Configure allauth to disable signups and redirect after login/logout

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6896d444750483229752d64700d2f158